### PR TITLE
Update zabaged_to_LandUseCode_table.yaml

### DIFF
--- a/config/zabaged_to_LandUseCode_table.yaml
+++ b/config/zabaged_to_LandUseCode_table.yaml
@@ -1,6 +1,4 @@
 land_use:
-  - keywords: [Orná, orná, Orna, orna]
-    code: 10000
   - keywords: [Travní, travní, Travni, travni]
     code: 20000
   - keywords: [Lesní, lesní, Lesni, lesni]
@@ -51,7 +49,7 @@ land_use:
     code: 55100
   - keywords: [Rozvodna, rozvodna]
     code: 44300 
-  - keywords: [Okrasna, okrasna, Okrasná, okrasná]
+  - keywords: [Udrzovana, udrzovana, Udržovaná, udržovaná]
     code: 44200
   - keywords: [Hřbitov, Hrbitov, hrbitov, hřbitov]
     code: 44200
@@ -65,8 +63,6 @@ land_use:
     code: 44100
   - keywords: [Bažina, bazina, Bazina, bažina]
     code: 66600
-  - keywords: [Tezba, těžba, tezba, Těžba]
-    code: 44100
   - keywords: [zřícenina, Zricenina, zricenina, Zřícenina]
     code: 44100   
   - keywords: [liniova, Liniova, Liniová, liniová]
@@ -79,9 +75,7 @@ land_use:
     code: 22200  
   - keywords: [Kulna, kulna, kůlna, Kulna]
     code: 44100  
-  - keywords: [Ostatni, ostanti, ostatní, Ostatní]
-    code: 44200
-  - keywords: [Těžba, tezba, Tezba, těžba]
+  - keywords: [Sidlech, sidlech, sídlech, Sídlech]
     code: 44200
   - keywords: [Letiste, letiste, letiště, Letiště]
     code: 20000


### PR DESCRIPTION
# odstraněny oba duplicitní výskyty klíčového slova "těžba". Kód přiřazen později podle vnitřního atributu dle ZABAGED,yaml 
# odstraněno klíčové slovo "orná". Kód vrstvě Orná půda a ONP bude přiřazen později dle vnitřního atributu dle ZABAGED.yaml. Druhé klíčové slovo "ostatní" změněno na "sídlech" aby se vztahovalo pouze na vrstvu Ostatní plcoha v sídlech. 
# Implementována změna jména vrstvy změnou klíčového slova "okrasná" --> "udržovaná".